### PR TITLE
minors

### DIFF
--- a/demo/GPMF_mp4reader.c
+++ b/demo/GPMF_mp4reader.c
@@ -120,7 +120,7 @@ uint32_t GetGPMFPayloadSize(uint32_t index)
 
 
 
-double OpenGPMFSourceUDTA(char *filename)
+double OpenGPMFSourceUDTA(const char *filename)
 {
 #ifdef _WINDOWS
 	fopen_s(&fp, filename, "rb");
@@ -213,7 +213,7 @@ double OpenGPMFSourceUDTA(char *filename)
 }
 
 
-double OpenGPMFSource(char *filename)  //RAW or within MP4
+double OpenGPMFSource(const char *filename)  //RAW or within MP4
 {
 #ifdef _WINDOWS
 	fopen_s(&fp, filename, "rb");

--- a/demo/GPMF_mp4reader.c
+++ b/demo/GPMF_mp4reader.c
@@ -739,6 +739,10 @@ double GetGPMFSampleRate(uint32_t fourcc, uint32_t flags)
 	uint32_t testend = indexcount;
 	double rate = 0.0;
 
+	uint32_t *payload;
+	uint32_t payloadsize;
+	int32_t ret;
+
 	if (indexcount < 1)
 		return 0.0;
 
@@ -748,9 +752,9 @@ double GetGPMFSampleRate(uint32_t fourcc, uint32_t flags)
 		testend--;
 	}
 
-	uint32_t *payload = GetGPMFPayload(NULL, teststart); // second payload
-	uint32_t payloadsize = GetGPMFPayloadSize(teststart);
-	int32_t ret = GPMF_Init(ms, payload, payloadsize);
+	payload = GetGPMFPayload(NULL, teststart); // second payload
+	payloadsize = GetGPMFPayloadSize(teststart);
+	ret = GPMF_Init(ms, payload, payloadsize);
 
 	if (ret != GPMF_OK)
 		goto cleanup;

--- a/demo/GPMF_mp4reader.h
+++ b/demo/GPMF_mp4reader.h
@@ -35,8 +35,8 @@ typedef struct SampleToChunk
 	uint32_t id;
 } SampleToChunk;
 
-double OpenGPMFSource(char *filename);
-double OpenGPMFSourceUDTA(char *filename);
+double OpenGPMFSource(const char *filename);
+double OpenGPMFSourceUDTA(const char *filename);
 void CloseGPMFSource(void);
 uint32_t GetNumberGPMFPayloads(void);
 uint32_t *GetGPMFPayload(uint32_t *lastpayload, uint32_t index);

--- a/samples/SAMPLES.md
+++ b/samples/SAMPLES.md
@@ -5,4 +5,4 @@
 | hero5.raw | A single raw GMPF payload | GoPro Hero 5 Black with v2.00 firmware |
 | hero5.mp4 | A 34 second low resolution MP4 with GMPF metadata track | GoPro Hero 5 Black with v2.00 firmware |
 | karma.raw | A single raw GMPF payload  | GoPro Hero 5 Black v2.00 attached Karma v1.0 |
-| hero5.mp4 | A 12 second low resolution MP4 with GMPF metadata track | GoPro Hero 5 Black v2.00 attached Karma v1.0 |
+| karma.mp4 | A 12 second low resolution MP4 with GMPF metadata track | GoPro Hero 5 Black v2.00 attached Karma v1.0 |


### PR DESCRIPTION
Minors:

 - foo(char *filename) -> foo(const char *filename)
 - SAMPLES.md mistype
 - VS2010 compilation fix

Thanks a lot for this repo!