### PR TITLE
Add cmake install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 # Debug files
 *.dSYM/
 *.su
+
+# pkg-config files
+/*.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,22 @@
-# CMakeLists.txt
-cmake_minimum_required (VERSION 3.8.2)
-project (gpmf-parser)
+cmake_minimum_required(VERSION 3.8.2)
+project(gpmf-parser)
 
 set(CMAKE_SUPPRESS_REGENERATION true)
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
 
-file(GLOB SOURCES GPMF_parser.c "demo/*.c")
+file(GLOB LIB_SOURCES "GPMF_parser.c" "demo/GPMF_mp4reader.c")
+file(GLOB SOURCES ${LIB_SOURCES} "demo/GPMF_demo.c" "demo/GPMF_print.c")
 
-add_executable(gpmf-parser ${SOURCES})
+add_executable(GPMF_PARSER_BIN ${SOURCES})
+set_target_properties(GPMF_PARSER_BIN PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
+add_library(GPMF_PARSER_LIB ${LIB_SOURCES})
+set_target_properties(GPMF_PARSER_LIB PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
+
+set(PC_LINK_FLAGS "-l${PROJECT_NAME}")
+configure_file("${PROJECT_NAME}.pc.in" "${PROJECT_NAME}.pc" @ONLY)
+
+install(TARGETS GPMF_PARSER_BIN DESTINATION "bin")
+install(TARGETS GPMF_PARSER_LIB DESTINATION "lib")
+install(FILES "${PROJECT_NAME}.pc" DESTINATION "lib/pkgconfig")
+install(FILES "GPMF_parser.h" "GPMF_common.h" DESTINATION "include/gpmf-parser")
+install(FILES "demo/GPMF_mp4reader.h" DESTINATION "include/gpmf-parser/demo")

--- a/gpmf-parser.pc.in
+++ b/gpmf-parser.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include/@PROJECT_NAME@
+
+Name: @PROJECT_NAME@
+Description: A low level GPMF parser
+Version: 1.2.2
+Libs: -L${libdir} @PC_LINK_FLAGS@
+Cflags: -I${includedir} -I${includedir}/demo


### PR DESCRIPTION
The cmake file now includes configuration to build a shared library, and supports `make install`, complete with a pkg-config file.