### PR TITLE
add CLI flags for showing STRMs/metadata, fix non-ASCII unit printing

### DIFF
--- a/GPMF_common.h
+++ b/GPMF_common.h
@@ -76,6 +76,12 @@ typedef enum
 
 #define MAKEID(a,b,c,d)			(((d&0xff)<<24)|((c&0xff)<<16)|((b&0xff)<<8)|(a&0xff))
 #define STR2FOURCC(s)			((s[0]<<0)|(s[1]<<8)|(s[2]<<16)|(s[3]<<24))
+#define FOURCC2STR(name, f) \
+char name[5] = {0,0,0,0,0}; \
+name[3] = (char)((f & 0xff000000) >> 24); \
+name[2] = (char)((f & 0x00ff0000) >> 16); \
+name[1] = (char)((f & 0x0000ff00) >>  8); \
+name[0] = (char)((f & 0x000000ff) >>  0);
 
 #define BYTESWAP64(a)			(((a&0xff)<<56)|((a&0xff00)<<40)|((a&0xff0000)<<24)|((a&0xff000000)<<8) | ((a>>56)&0xff)|((a>>40)&0xff00)|((a>>24)&0xff0000)|((a>>8)&0xff000000) )
 #define BYTESWAP32(a)			(((a&0xff)<<24)|((a&0xff00)<<8)|((a>>8)&0xff00)|((a>>24)&0xff))

--- a/GPMF_parser.c
+++ b/GPMF_parser.c
@@ -347,6 +347,38 @@ GPMF_ERR GPMF_Next(GPMF_stream *ms, GPMF_LEVELS recurse)
 
 
 
+GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, GPMF_LEVELS recurse)
+{
+	GPMF_stream prevstate;
+
+	if (ms)
+	{
+		memcpy(&prevstate, ms, sizeof(GPMF_stream));
+
+		if (ms->pos < ms->buffer_size_longs)
+		{
+			while (0 == GPMF_Next(ms, recurse))
+			{
+				if (strms) {
+					char** strm = strms;
+					int len = sizeof(strms) / sizeof(strms[0]);
+					for (int i = 0; i < len; i++) {
+						if (ms->buffer[ms->pos] == STR2FOURCC(strms[i]))
+						{
+							return GPMF_OK; //found match
+						}
+					}
+				}
+			}
+
+			// restore read position
+			memcpy(ms, &prevstate, sizeof(GPMF_stream));
+			return GPMF_ERROR_FIND;
+		}
+	}
+	return GPMF_ERROR_FIND;
+}
+
 GPMF_ERR GPMF_FindNext(GPMF_stream *ms, uint32_t fourcc, GPMF_LEVELS recurse)
 {
 	GPMF_stream prevstate;

--- a/GPMF_parser.c
+++ b/GPMF_parser.c
@@ -347,41 +347,6 @@ GPMF_ERR GPMF_Next(GPMF_stream *ms, GPMF_LEVELS recurse)
 
 
 
-GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, int numStrms, GPMF_LEVELS recurse)
-{
-	GPMF_stream prevstate;
-
-	if (ms)
-	{
-		memcpy(&prevstate, ms, sizeof(GPMF_stream));
-
-		if (ms->pos < ms->buffer_size_longs)
-		{
-			while (0 == GPMF_Next(ms, recurse))
-			{
-				uint32_t fourcc = ms->buffer[ms->pos];
-				if (strms) {
-					char** strm = strms;
-					for (int i = 0; i < numStrms; i++) {
-						if (!strms[i]) continue;
-						uint32_t cur = STR2FOURCC(strms[i]);
-						if (fourcc == cur)
-						{
-							strms[i] = NULL;
-							return GPMF_OK; //found match
-						}
-					}
-				}
-			}
-
-			// restore read position
-			memcpy(ms, &prevstate, sizeof(GPMF_stream));
-			return GPMF_ERROR_FIND;
-		}
-	}
-	return GPMF_ERROR_FIND;
-}
-
 GPMF_ERR GPMF_FindNext(GPMF_stream *ms, uint32_t fourcc, GPMF_LEVELS recurse)
 {
 	GPMF_stream prevstate;

--- a/GPMF_parser.c
+++ b/GPMF_parser.c
@@ -347,7 +347,7 @@ GPMF_ERR GPMF_Next(GPMF_stream *ms, GPMF_LEVELS recurse)
 
 
 
-GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, GPMF_LEVELS recurse)
+GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, int numStrms, GPMF_LEVELS recurse)
 {
 	GPMF_stream prevstate;
 
@@ -359,12 +359,15 @@ GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, GPMF_LEVELS recurse)
 		{
 			while (0 == GPMF_Next(ms, recurse))
 			{
+				uint32_t fourcc = ms->buffer[ms->pos];
 				if (strms) {
 					char** strm = strms;
-					int len = sizeof(strms) / sizeof(strms[0]);
-					for (int i = 0; i < len; i++) {
-						if (ms->buffer[ms->pos] == STR2FOURCC(strms[i]))
+					for (int i = 0; i < numStrms; i++) {
+						if (!strms[i]) continue;
+						uint32_t cur = STR2FOURCC(strms[i]);
+						if (fourcc == cur)
 						{
+							strms[i] = NULL;
 							return GPMF_OK; //found match
 						}
 					}

--- a/GPMF_parser.h
+++ b/GPMF_parser.h
@@ -66,7 +66,6 @@ GPMF_ERR GPMF_Validate(GPMF_stream *gs, GPMF_LEVELS recurse);									//Is the n
 // Navigate through GPMF data
 GPMF_ERR GPMF_Next(GPMF_stream *gs, GPMF_LEVELS recurse);										//Step to the next GPMF KLV entrance, optionally recurse up or down nesting levels.
 GPMF_ERR GPMF_FindPrev(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a previous FourCC -- at the current level only if recurse is false
-GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, int numStrms, GPMF_LEVELS recurse);
 GPMF_ERR GPMF_FindNext(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a particular FourCC upcoming -- at the current level only if recurse is false
 GPMF_ERR GPMF_SeekToSamples(GPMF_stream *gs);													//find the last FourCC in the current level, this is raw data for any STRM
 

--- a/GPMF_parser.h
+++ b/GPMF_parser.h
@@ -66,7 +66,7 @@ GPMF_ERR GPMF_Validate(GPMF_stream *gs, GPMF_LEVELS recurse);									//Is the n
 // Navigate through GPMF data
 GPMF_ERR GPMF_Next(GPMF_stream *gs, GPMF_LEVELS recurse);										//Step to the next GPMF KLV entrance, optionally recurse up or down nesting levels.
 GPMF_ERR GPMF_FindPrev(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a previous FourCC -- at the current level only if recurse is false
-GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, GPMF_LEVELS recurse);
+GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, int numStrms, GPMF_LEVELS recurse);
 GPMF_ERR GPMF_FindNext(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a particular FourCC upcoming -- at the current level only if recurse is false
 GPMF_ERR GPMF_SeekToSamples(GPMF_stream *gs);													//find the last FourCC in the current level, this is raw data for any STRM
 

--- a/GPMF_parser.h
+++ b/GPMF_parser.h
@@ -55,17 +55,18 @@ typedef enum GPMF_LEVELS
 	GPMF_RECURSE_LEVELS
 } GPMF_LEVELS;
 
- 
 
-// Prepare GPMF data 
+
+// Prepare GPMF data
 GPMF_ERR GPMF_Init(GPMF_stream *gs, uint32_t *buffer, int datasize);							//Initialize a GPMF_stream for parsing a particular buffer.
 GPMF_ERR GPMF_ResetState(GPMF_stream *gs);														//Read from beginning of the buffer again
-GPMF_ERR GPMF_CopyState(GPMF_stream *src, GPMF_stream *dst);									//Copy state, 
-GPMF_ERR GPMF_Validate(GPMF_stream *gs, GPMF_LEVELS recurse);									//Is the nest structure valid GPMF? 
+GPMF_ERR GPMF_CopyState(GPMF_stream *src, GPMF_stream *dst);									//Copy state,
+GPMF_ERR GPMF_Validate(GPMF_stream *gs, GPMF_LEVELS recurse);									//Is the nest structure valid GPMF?
 
-// Navigate through GPMF data 
+// Navigate through GPMF data
 GPMF_ERR GPMF_Next(GPMF_stream *gs, GPMF_LEVELS recurse);										//Step to the next GPMF KLV entrance, optionally recurse up or down nesting levels.
 GPMF_ERR GPMF_FindPrev(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a previous FourCC -- at the current level only if recurse is false
+GPMF_ERR GPMF_FindNextMulti(GPMF_stream *ms, char** strms, GPMF_LEVELS recurse);
 GPMF_ERR GPMF_FindNext(GPMF_stream *gs, uint32_t fourCC, GPMF_LEVELS recurse);					//find a particular FourCC upcoming -- at the current level only if recurse is false
 GPMF_ERR GPMF_SeekToSamples(GPMF_stream *gs);													//find the last FourCC in the current level, this is raw data for any STRM
 

--- a/demo/makefile
+++ b/demo/makefile
@@ -1,5 +1,5 @@
-gpmfdemo : GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o
-		gcc -o gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o -lasan
+gpmfdemo : GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o str_split.o
+		gcc -o gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o str_split.o -lasan
 
 GPMF_demo.o : GPMF_demo.c ../GPMF_parser.h
 		gcc -g -c GPMF_demo.c
@@ -9,5 +9,7 @@ GPMF_print.o : GPMF_print.c ../GPMF_parser.h
 		gcc -g -c GPMF_print.c
 GPMF_parser.o : ../GPMF_parser.c ../GPMF_parser.h
 		gcc -g -c ../GPMF_parser.c
+str_split.o : str_split.c str_split.h
+		gcc -g -c str_split.c
 clean :
-		rm gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o
+		rm gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o str_split.o

--- a/demo/str_split.c
+++ b/demo/str_split.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+// Copied from https://stackoverflow.com/a/9210560
+char** str_split(char* a_str, const char a_delim)
+{
+    char** result    = 0;
+    size_t count     = 0;
+    char* tmp        = a_str;
+    char* last_comma = 0;
+    char delim[2];
+    delim[0] = a_delim;
+    delim[1] = 0;
+
+    /* Count how many elements will be extracted. */
+    while (*tmp)
+    {
+        if (a_delim == *tmp)
+        {
+            count++;
+            last_comma = tmp;
+        }
+        tmp++;
+    }
+
+    /* Add space for trailing token. */
+    count += last_comma < (a_str + strlen(a_str) - 1);
+
+    /* Add space for terminating null string so caller
+       knows where the list of returned strings ends. */
+    count++;
+
+    result = malloc(sizeof(char*) * count);
+
+    if (result)
+    {
+        size_t idx  = 0;
+        char* token = strtok(a_str, delim);
+
+        while (token)
+        {
+            assert(idx < count);
+            *(result + idx++) = strdup(token);
+            token = strtok(0, delim);
+        }
+        assert(idx == count - 1);
+        *(result + idx) = 0;
+    }
+
+    return result;
+}

--- a/demo/str_split.h
+++ b/demo/str_split.h
@@ -1,0 +1,1 @@
+char** str_split(char* a_str, const char a_delim);


### PR DESCRIPTION
test it locally:
```bash
docker run runsascoded/gpmf-parser:cli samples/hero8.mp4 -s GPS5,ACCL -LR
```
```
MP4 Payload time 0.000 to 1.001 seconds
GPS5 42.027deg, -129.294deg, 9540.240m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.294deg, 9540.182m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.294deg, 9540.123m, 0.000m/s, 0.000m/s,
…

MP4 Payload time 0.000 to 1.001 seconds
ACCL 9.832m/s², 1.038m/s², -0.053m/s²,
ACCL 10.024m/s², 0.803m/s², 0.058m/s²,
ACCL 10.094m/s², 0.873m/s², 0.317m/s²,
…
```

<details>
<summary>Full Output</summary>

```
MP4 Payload time 0.000 to 1.001 seconds
GPS5 42.027deg, -129.294deg, 9540.240m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.294deg, 9540.182m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.294deg, 9540.123m, 0.000m/s, 0.000m/s,
GPS5 42.578deg, -129.517deg, 9745.102m, 0.000m/s, 0.000m/s,
GPS5 42.578deg, -129.517deg, 9745.046m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.293deg, 9539.947m, 0.000m/s, 0.000m/s,
GPS5 42.026deg, -129.292deg, 9539.889m, 0.000m/s, 0.000m/s,
GPS5 42.578deg, -129.516deg, 9744.876m, 0.000m/s, 0.000m/s,
GPS5 42.578deg, -129.515deg, 9744.820m, 0.000m/s, 0.000m/s,
GPS5 42.265deg, -129.388deg, 9628.708m, 0.000m/s, 0.000m/s,
GPS5 42.265deg, -129.388deg, 9628.650m, 0.000m/s, 0.000m/s,
GPS5 42.265deg, -129.387deg, 9628.593m, 0.000m/s, 0.000m/s,
GPS5 41.705deg, -129.163deg, 9421.185m, 0.000m/s, 0.000m/s,
GPS5 41.705deg, -129.163deg, 9421.125m, 0.000m/s, 0.000m/s,
GPS5 38.433deg, -127.929deg, 8220.372m, 0.000m/s, 0.000m/s,
GPS5 38.433deg, -127.929deg, 8220.301m, 0.000m/s, 0.000m/s,
GPS5 38.433deg, -127.928deg, 8220.230m, 0.000m/s, 0.000m/s,
GPS5 38.041deg, -127.788deg, 8078.376m, 0.000m/s, 0.000m/s,
GPS5 37.665deg, -127.655deg, 7942.678m, 0.000m/s, 0.000m/s,

MP4 Payload time 0.000 to 1.001 seconds
ACCL 9.832m/s², 1.038m/s², -0.053m/s²,
ACCL 10.024m/s², 0.803m/s², 0.058m/s²,
ACCL 10.094m/s², 0.873m/s², 0.317m/s²,
ACCL 10.153m/s², 1.005m/s², 0.659m/s²,
ACCL 10.261m/s², 1.134m/s², 0.626m/s²,
ACCL 10.513m/s², 1.084m/s², 0.906m/s²,
ACCL 10.777m/s², 1.187m/s², 0.839m/s²,
ACCL 10.369m/s², 1.540m/s², 0.705m/s²,
ACCL 10.588m/s², 1.645m/s², 1.369m/s²,
ACCL 10.516m/s², 1.695m/s², 1.412m/s²,
ACCL 10.415m/s², 2.247m/s², 0.679m/s²,
ACCL 10.384m/s², 2.209m/s², 1.331m/s²,
ACCL 10.348m/s², 2.441m/s², 1.175m/s²,
ACCL 10.204m/s², 2.820m/s², 0.508m/s²,
ACCL 10.175m/s², 2.751m/s², 0.938m/s²,
ACCL 10.026m/s², 3.125m/s², 0.566m/s²,
ACCL 10.079m/s², 3.213m/s², 0.108m/s²,
ACCL 10.736m/s², 2.254m/s², -0.149m/s²,
ACCL 10.189m/s², 2.597m/s², -0.077m/s²,
ACCL 10.005m/s², 2.866m/s², 0.192m/s²,
ACCL 10.043m/s², 2.602m/s², 0.384m/s²,
ACCL 9.964m/s², 2.966m/s², -0.317m/s²,
ACCL 9.947m/s², 2.962m/s², -0.353m/s²,
ACCL 9.887m/s², 2.667m/s², 0.146m/s²,
ACCL 9.835m/s², 2.707m/s², -0.683m/s²,
ACCL 9.827m/s², 2.314m/s², -0.530m/s²,
ACCL 9.767m/s², 2.213m/s², -0.384m/s²,
ACCL 9.698m/s², 2.305m/s², -0.832m/s²,
ACCL 9.763m/s², 1.887m/s², -0.813m/s²,
ACCL 9.693m/s², 1.616m/s², -0.897m/s²,
ACCL 9.683m/s², 1.307m/s², -1.074m/s²,
ACCL 9.767m/s², 0.928m/s², -1.079m/s²,
ACCL 9.686m/s², 1.115m/s², -1.067m/s²,
ACCL 9.688m/s², 1.065m/s², -0.830m/s²,
ACCL 9.669m/s², 0.938m/s², -0.753m/s²,
ACCL 9.703m/s², 0.765m/s², -0.765m/s²,
ACCL 9.753m/s², 0.400m/s², -0.501m/s²,
ACCL 9.758m/s², 0.288m/s², -0.537m/s²,
ACCL 9.755m/s², 0.230m/s², -0.612m/s²,
ACCL 9.755m/s², 0.293m/s², -0.451m/s²,
ACCL 9.775m/s², 0.552m/s², -0.444m/s²,
ACCL 9.760m/s², 0.882m/s², -0.209m/s²,
ACCL 9.758m/s², 1.252m/s², 0.048m/s²,
ACCL 9.751m/s², 1.468m/s², 0.151m/s²,
ACCL 9.734m/s², 1.460m/s², 0.216m/s²,
ACCL 9.751m/s², 1.528m/s², 0.240m/s²,
ACCL 9.782m/s², 1.624m/s², 0.230m/s²,
ACCL 9.765m/s², 1.717m/s², 0.261m/s²,
ACCL 9.719m/s², 1.986m/s², 0.242m/s²,
ACCL 9.659m/s², 2.312m/s², 0.357m/s²,
ACCL 9.544m/s², 2.600m/s², 0.453m/s²,
ACCL 9.504m/s², 2.731m/s², 0.302m/s²,
ACCL 9.496m/s², 2.705m/s², 0.173m/s²,
ACCL 9.518m/s², 2.621m/s², 0.089m/s²,
ACCL 9.556m/s², 2.518m/s², -0.014m/s²,
ACCL 9.609m/s², 2.496m/s², -0.077m/s²,
ACCL 9.554m/s², 2.544m/s², -0.108m/s²,
ACCL 9.544m/s², 2.626m/s², -0.211m/s²,
ACCL 9.600m/s², 2.556m/s², -0.516m/s²,
ACCL 9.537m/s², 2.391m/s², -0.959m/s²,
ACCL 9.192m/s², 2.882m/s², -0.779m/s²,
ACCL 9.712m/s², 2.230m/s², -0.072m/s²,
ACCL 10.002m/s², 1.775m/s², -1.540m/s²,
ACCL 9.468m/s², 2.628m/s², -1.588m/s²,
ACCL 9.585m/s², 1.849m/s², 0.631m/s²,
ACCL 9.751m/s², 2.758m/s², -1.062m/s²,
ACCL 9.525m/s², 3.276m/s², -0.763m/s²,
ACCL 9.458m/s², 2.422m/s², 1.851m/s²,
ACCL 9.631m/s², 2.880m/s², 0.257m/s²,
ACCL 9.894m/s², 2.264m/s², 0.285m/s²,
ACCL 9.695m/s², 2.070m/s², 1.863m/s²,
ACCL 9.568m/s², 2.748m/s², 1.482m/s²,
ACCL 9.940m/s², 2.216m/s², 1.319m/s²,
ACCL 9.815m/s², 2.585m/s², 1.170m/s²,
ACCL 9.607m/s², 2.787m/s², 1.460m/s²,
ACCL 9.861m/s², 2.144m/s², 1.247m/s²,
ACCL 9.758m/s², 2.436m/s², -0.074m/s²,
ACCL 9.612m/s², 2.134m/s², 0.501m/s²,
ACCL 9.628m/s², 1.923m/s², 0.535m/s²,
ACCL 9.619m/s², 2.278m/s², -0.787m/s²,
ACCL 9.578m/s², 1.811m/s², -0.381m/s²,
ACCL 9.444m/s², 1.839m/s², -0.381m/s²,
ACCL 9.561m/s², 1.818m/s², -1.058m/s²,
ACCL 9.700m/s², 1.415m/s², -0.871m/s²,
ACCL 9.513m/s², 1.753m/s², -0.693m/s²,
ACCL 9.561m/s², 1.645m/s², -0.487m/s²,
ACCL 9.722m/s², 1.336m/s², -0.583m/s²,
ACCL 9.707m/s², 1.403m/s², -0.621m/s²,
ACCL 9.784m/s², 0.976m/s², -0.012m/s²,
ACCL 9.894m/s², 0.904m/s², -0.249m/s²,
ACCL 9.868m/s², 1.029m/s², -0.317m/s²,
ACCL 9.779m/s², 0.894m/s², 0.405m/s²,
ACCL 9.700m/s², 1.065m/s², 0.187m/s²,
ACCL 9.729m/s², 0.815m/s², -0.067m/s²,
ACCL 9.731m/s², 0.516m/s², 0.209m/s²,
ACCL 9.679m/s², 0.669m/s², 0.252m/s²,
ACCL 9.712m/s², 0.652m/s², 0.494m/s²,
ACCL 9.683m/s², 0.801m/s², 0.686m/s²,
ACCL 9.671m/s², 1.070m/s², 1.029m/s²,
ACCL 9.715m/s², 1.050m/s², 1.405m/s²,
ACCL 9.734m/s², 1.264m/s², 1.314m/s²,
ACCL 9.739m/s², 1.297m/s², 1.475m/s²,
ACCL 9.775m/s², 1.213m/s², 1.628m/s²,
ACCL 9.765m/s², 1.453m/s², 1.465m/s²,
ACCL 9.731m/s², 1.724m/s², 1.597m/s²,
ACCL 9.643m/s², 2.120m/s², 1.671m/s²,
ACCL 9.573m/s², 2.453m/s², 1.465m/s²,
ACCL 9.547m/s², 2.484m/s², 1.362m/s²,
ACCL 9.523m/s², 2.504m/s², 1.118m/s²,
ACCL 9.516m/s², 2.448m/s², 0.911m/s²,
ACCL 9.482m/s², 2.475m/s², 0.887m/s²,
ACCL 9.391m/s², 2.801m/s², 0.868m/s²,
ACCL 9.290m/s², 3.019m/s², 1.158m/s²,
ACCL 9.326m/s², 3.101m/s², 1.261m/s²,
ACCL 9.357m/s², 3.038m/s², 1.113m/s²,
ACCL 9.465m/s², 2.803m/s², 1.230m/s²,
ACCL 9.571m/s², 2.818m/s², 1.312m/s²,
ACCL 9.602m/s², 2.926m/s², 1.290m/s²,
ACCL 9.619m/s², 3.002m/s², 1.403m/s²,
ACCL 9.544m/s², 3.103m/s², 1.480m/s²,
ACCL 9.549m/s², 3.067m/s², 1.528m/s²,
ACCL 9.645m/s², 2.923m/s², 1.496m/s²,
ACCL 9.688m/s², 2.928m/s², 1.408m/s²,
ACCL 9.712m/s², 2.832m/s², 1.405m/s²,
ACCL 9.698m/s², 2.892m/s², 1.482m/s²,
ACCL 9.674m/s², 2.940m/s², 1.578m/s²,
ACCL 9.657m/s², 2.933m/s², 1.844m/s²,
ACCL 9.719m/s², 2.954m/s², 2.010m/s²,
ACCL 9.741m/s², 3.038m/s², 2.218m/s²,
ACCL 9.727m/s², 3.163m/s², 2.453m/s²,
ACCL 9.777m/s², 3.213m/s², 2.537m/s²,
ACCL 9.767m/s², 3.115m/s², 2.602m/s²,
ACCL 9.746m/s², 2.890m/s², 2.520m/s²,
ACCL 9.734m/s², 2.808m/s², 2.355m/s²,
ACCL 9.729m/s², 2.743m/s², 2.173m/s²,
ACCL 9.647m/s², 2.746m/s², 1.887m/s²,
ACCL 9.621m/s², 2.679m/s², 1.568m/s²,
ACCL 9.580m/s², 2.561m/s², 1.221m/s²,
ACCL 9.530m/s², 2.398m/s², 0.799m/s²,
ACCL 9.520m/s², 2.110m/s², 0.496m/s²,
ACCL 9.516m/s², 1.844m/s², 0.285m/s²,
ACCL 9.482m/s², 1.693m/s², 0.156m/s²,
ACCL 9.429m/s², 1.573m/s², 0.204m/s²,
ACCL 9.388m/s², 1.472m/s², 0.192m/s²,
ACCL 9.441m/s², 1.254m/s², 0.218m/s²,
ACCL 9.532m/s², 0.904m/s², 0.276m/s²,
ACCL 9.609m/s², 0.566m/s², 0.149m/s²,
ACCL 9.712m/s², 0.293m/s², 0.134m/s²,
ACCL 9.736m/s², 0.137m/s², 0.242m/s²,
ACCL 9.674m/s², 0.077m/s², 0.384m/s²,
ACCL 9.602m/s², 0.019m/s², 0.420m/s²,
ACCL 9.647m/s², -0.201m/s², 0.331m/s²,
ACCL 9.746m/s², -0.511m/s², 0.194m/s²,
ACCL 9.746m/s², -0.616m/s², 0.132m/s²,
ACCL 9.681m/s², -0.564m/s², 0.163m/s²,
ACCL 9.657m/s², -0.564m/s², 0.170m/s²,
ACCL 9.626m/s², -0.511m/s², 0.312m/s²,
ACCL 9.564m/s², -0.412m/s², 0.655m/s²,
ACCL 9.556m/s², -0.400m/s², 1.022m/s²,
ACCL 9.549m/s², -0.436m/s², 1.223m/s²,
ACCL 9.535m/s², -0.484m/s², 1.376m/s²,
ACCL 9.571m/s², -0.576m/s², 1.513m/s²,
ACCL 9.585m/s², -0.477m/s², 1.489m/s²,
ACCL 9.590m/s², -0.285m/s², 1.355m/s²,
ACCL 9.573m/s², -0.110m/s², 1.302m/s²,
ACCL 9.508m/s², 0.096m/s², 1.180m/s²,
ACCL 9.475m/s², 0.199m/s², 1.024m/s²,
ACCL 9.427m/s², 0.225m/s², 0.904m/s²,
ACCL 9.422m/s², 0.300m/s², 0.847m/s²,
ACCL 9.420m/s², 0.472m/s², 0.957m/s²,
ACCL 9.374m/s², 0.743m/s², 1.146m/s²,
ACCL 9.297m/s², 0.986m/s², 1.264m/s²,
ACCL 9.218m/s², 1.146m/s², 1.388m/s²,
ACCL 9.149m/s², 1.281m/s², 1.508m/s²,
ACCL 9.158m/s², 1.360m/s², 1.647m/s²,
ACCL 9.180m/s², 1.410m/s², 1.645m/s²,
ACCL 9.170m/s², 1.501m/s², 1.616m/s²,
ACCL 9.173m/s², 1.652m/s², 1.621m/s²,
ACCL 9.182m/s², 1.789m/s², 1.544m/s²,
ACCL 9.165m/s², 1.839m/s², 1.434m/s²,
ACCL 9.233m/s², 1.772m/s², 1.405m/s²,
ACCL 9.341m/s², 1.707m/s², 1.369m/s²,
ACCL 9.396m/s², 1.861m/s², 1.489m/s²,
ACCL 9.391m/s², 2.192m/s², 1.866m/s²,
ACCL 9.376m/s², 2.446m/s², 2.153m/s²,
ACCL 9.408m/s², 2.540m/s², 2.336m/s²,
ACCL 9.508m/s², 2.429m/s², 2.544m/s²,
ACCL 9.595m/s², 2.343m/s², 2.734m/s²,
ACCL 9.621m/s², 2.242m/s², 2.823m/s²,
ACCL 9.602m/s², 2.266m/s², 2.871m/s²,
ACCL 9.552m/s², 2.439m/s², 2.926m/s²,
ACCL 9.496m/s², 2.532m/s², 2.914m/s²,
ACCL 9.547m/s², 2.554m/s², 2.600m/s²,
ACCL 9.561m/s², 2.482m/s², 2.261m/s²,
ACCL 9.561m/s², 2.348m/s², 1.897m/s²,
ACCL 9.544m/s², 2.290m/s², 1.559m/s²,
ACCL 9.482m/s², 2.338m/s², 1.381m/s²,
ACCL 9.422m/s², 2.417m/s², 1.271m/s²,
ACCL 9.386m/s², 2.379m/s², 1.264m/s²,
ACCL 9.412m/s², 2.254m/s², 1.199m/s²,
ACCL 9.465m/s², 2.153m/s², 1.153m/s²,
ACCL 9.494m/s², 2.007m/s², 1.096m/s²,

```

</details>

- `-L` suppresses the initial STRM list
- `-R` suppresses the final "sample rate" listing
- `-s` provides 1 or more STRMs (default: `ACCL`) to print raw samples for
  - xor: `-S` disables printing raw samples

The `runsascoded/gpmf-parser:cli` docker image can be made `runsascoded/gpmf-parser:latest` when this or #96 is merged.