### PR TITLE
cmake: add missing header GPMF_utils.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,4 +21,4 @@ install(TARGETS GPMF_PARSER_LIB DESTINATION "lib")
 install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION "lib/pkgconfig")
 
 install(FILES "GPMF_parser.h" "GPMF_common.h" DESTINATION "include/gpmf-parser")
-install(FILES "demo/GPMF_mp4reader.h" DESTINATION "include/gpmf-parser/demo")
+install(FILES "demo/GPMF_mp4reader.h" "demo/GPMF_utils.h" DESTINATION "include/gpmf-parser/demo")


### PR DESCRIPTION
Add missing public header GPMF_utils.h (used by client such as lib-gpmf)