### PR TITLE
improved logic for stsz atom

### DIFF
--- a/demo/GPMF_mp4reader.c
+++ b/demo/GPMF_mp4reader.c
@@ -474,7 +474,7 @@ size_t OpenMP4Source(char *filename, uint32_t traktype, uint32_t traksubtype)  /
 
 							num = BYTESWAP32(num);
 							// if equalsamplesize != 0, it is the size of all the samples and the length should be 20 (size,fourcc,flags,samplesize,samplecount)
-							if ((num <= (qtsize/sizeof(uint32_t))) || (equalsamplesize != 0 && qtsize == 20))
+                            if (qtsize >= (20 + (num * sizeof(uint32_t))) || (equalsamplesize != 0 && qtsize == 20))
 							{
 								if (mp4->metasizes)
 								{
@@ -482,7 +482,7 @@ size_t OpenMP4Source(char *filename, uint32_t traktype, uint32_t traksubtype)  /
 									mp4->metasizes = 0;
 								}
 								//either the samples are different sizes or they are all the same size
-								if(num > 0 && ((qtsize > (num * 4)) || (equalsamplesize != 0 && qtsize == 20)))
+								if(num > 0)
 								{
 									mp4->metasize_count = num;
 									mp4->metasizes = (uint32_t *)malloc(num * 4);


### PR DESCRIPTION
- make outer check solid for both use cases; either:
  - qtsize is 20 and samples have a uniform size; OR
  - qtsize is >= 20 + num * 4 and samples have a non-uniform size
    (20 = the size of the atom header incl flags and version plus
    the size of the size field plus the size of the count field)
- this outer logic means that the inner conditional can be simplified