### PR TITLE
Added fuzzer for initial integration with OSS-Fuzz.

### DIFF
--- a/fuzz/fuzz_parse.c
+++ b/fuzz/fuzz_parse.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include "../GPMF_parser.h"
+#include "GPMF_mp4reader.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    OpenMP4Source(filename, MOV_GPMF_TRAK_TYPE, MOV_GPMF_TRAK_SUBTYPE);
+
+    unlink(filename);
+    return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for gpmf-parser by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, and it would be great to have gpmf-parser integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/5281 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate gpmf-parser. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I stored the fuzzers in the Google OSS-Fuzz repository, but we can move them up here to make maintenance easier.