### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,8 @@
 !GPMF_common.h
 !GPMF_parser.c
 !GPMF_parser.h
+!GPMF_utils.h
+!GPMF_utils.c
 !LICENSE-APACHE
 !LICENSE-MIT
 !LICENSE.txt

--- a/demo/makefile
+++ b/demo/makefile
@@ -8,10 +8,10 @@ ifneq ($(OS),Windows_NT)
 	endif
 endif
 
-gpmfdemo : GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o
-		gcc -o gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o $(ASAN_FLAGS)
+gpmfdemo : GPMF_demo.o GPMF_parser.o GPMF_utils.o GPMF_mp4reader.o GPMF_print.o
+		gcc -o gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_utils.o GPMF_mp4reader.o GPMF_print.o $(ASAN_FLAGS)
 
-GPMF_demo.o : GPMF_demo.c ../GPMF_parser.h
+GPMF_demo.o : GPMF_demo.c
 		gcc -g -c GPMF_demo.c
 GPMF_mp4reader.o : GPMF_mp4reader.c ../GPMF_parser.h
 		gcc -g -c GPMF_mp4reader.c
@@ -19,5 +19,7 @@ GPMF_print.o : GPMF_print.c ../GPMF_parser.h
 		gcc -g -c GPMF_print.c
 GPMF_parser.o : ../GPMF_parser.c ../GPMF_parser.h
 		gcc -g -c ../GPMF_parser.c
+GPMF_utils.o : ../GPMF_utils.c ../GPMF_utils.h
+		gcc -g -c ../GPMF_utils.c
 clean :
-		rm gpmfdemo GPMF_demo.o GPMF_parser.o GPMF_mp4reader.o GPMF_print.o
+		rm gpmfdemo *.o


### PR DESCRIPTION
The docker build was failing with:
```
gcc -g -c GPMF_demo.c
GPMF_demo.c:29:10: fatal error: ../GPMF_utils.h: No such file or directory
   29 | #include "../GPMF_utils.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

P.S. For some reason I'm unable to open the CLA server (connection to `cla.gopro.com(54.149.249.9:443)` is timing out).