### PR TITLE
Fix for short files with multiple single sample meta track entries

### DIFF
--- a/demo/GPMF_mp4reader.c
+++ b/demo/GPMF_mp4reader.c
@@ -892,7 +892,7 @@ size_t OpenMP4Source(char *filename, uint32_t traktype, uint32_t traksubtype, in
 
 									totaldur += duration;
 									mp4->metadatalength += (double)((double)samplecount * (double)duration / (double)mp4->meta_clockdemon);
-									if (samplecount > 1 || num == 1)
+									if (samples > 1 || num == 1)
 										mp4->basemetadataduration = mp4->metadatalength * (double)mp4->meta_clockdemon / (double)samples;
 								}
 							}


### PR DESCRIPTION
This fixes an issue with very short MP4 (<2sec), having two or more single sample entries in the meta track. In that case, the Demo project would fail on `GetPayloadTime`, and pretend that the MP4 contains corrupted data.